### PR TITLE
Migrate to @asyncio.coroutine to async/await syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # waqi-async
 Async python library for http://aqicn.org
 
-Requires Python 3.4+
+Requires Python 3.5+
 
 To install
 ```

--- a/waqiasync/__init__.py
+++ b/waqiasync/__init__.py
@@ -26,24 +26,22 @@ class WaqiClient(object):
         else:
             self._session = aiohttp.ClientSession()
 
-    @asyncio.coroutine
-    def search(self, keyword):
+    async def search(self, keyword):
         """Search for a station/location by name."""
-        return (yield from self._get(SEARCH_URL, keyword=keyword))
+        return await self._get(SEARCH_URL, keyword=keyword)
 
-    @asyncio.coroutine
-    def get_station_by_name(self, name):
+    async def get_station_by_name(self, name):
         """Get data by station name."""
-        return (yield from self._get(FEED_NAME_URL.format(name)))
+        return await self._get(FEED_NAME_URL.format(name))
 
-    @asyncio.coroutine
-    def get_station_by_number(self, number):
+    async def get_station_by_number(self, number):
         """Get data by station number."""
-        return (yield from self._get(FEED_NUMBER_URL.format(number)))
+        return await self._get(FEED_NUMBER_URL.format(number))
 
-    @asyncio.coroutine
-    def _get(self, path, **kwargs):
+    async def _get(self, path, **kwargs):
         with async_timeout.timeout(self._timeout):
-            resp = yield from self._session.get(
-                path, params=dict(self._params, **kwargs))
-            return (yield from resp.json())['data']
+            async with self._session.get(
+                path, params=dict(self._params, **kwargs)
+            ) as r:
+                result = await r.json()
+                return result["data"]


### PR DESCRIPTION
Migrate to async/await syntax. Addresses https://github.com/andrey-git/waqi-async/issues/4.  Generator-based coroutines are removed in 3.11 (https://docs.python.org/3.10/library/asyncio-task.html#generator-based-coroutines).  
 